### PR TITLE
Backlog-15819: Page composer access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-depends>default,contentRetrieval,jcrestapi</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MC0CFCmqVJtrz0kAyOqFGUNBcVadgNRpAhUAjw7e/EW/Uagp8Btq800Wvs7LUOA=</jahia-module-signature>
+        <jahia-module-signature>MC0CFBOUiWJoc8+JdkWi4+SqQFugiLD+AhUAh+/le+4aPIM9zmAqsUGRiGZaShk=</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.0.0.0</version>
+        <version>8.0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>userDashboard</artifactId>

--- a/src/main/resources/jnt_listSites/html/sitesTableRow.settingsBootstrap3GoogleMaterialStyle.jspf
+++ b/src/main/resources/jnt_listSites/html/sitesTableRow.settingsBootstrap3GoogleMaterialStyle.jspf
@@ -22,7 +22,7 @@
             </c:otherwise>
         </c:choose>
         <c:choose>
-            <c:when test="${not empty node and (jcr:hasPermission(node,'jContentAccess') || jcr:hasPermission(node,'contributeModeAccess'))}">
+            <c:when test="${not empty node and (jcr:hasPermission(node,'jContentAccess') || jcr:hasPermission(node,'pageComposerAccess') || jcr:hasPermission(node,'contributeModeAccess'))}">
                 <c:set var="baseLive" value="${url.baseLive}"/>
                 <c:set var="basePreview" value="${url.basePreview}"/>
                 <c:set var="baseContribute" value="${url.baseContribute}"/>
@@ -52,6 +52,11 @@
                     <td>
                         <c:choose>
                             <c:when test="${jcr:hasPermission(node,'jContentAccess') && !renderContext.settings.readOnlyMode && !renderContext.settings.distantPublicationServerMode && not remotelyPublished}">
+                                <a href="<c:url value='/jahia/jcontent/${node.siteKey}/${siteLocale}/pages'/>" target="_parent">
+                                    <i class="material-icons">arrow_forward</i>
+                                </a>
+                            </c:when>
+                            <c:when test="${jcr:hasPermission(node,'pageComposerAccess') && !renderContext.settings.readOnlyMode && !renderContext.settings.distantPublicationServerMode && not remotelyPublished}">
                                 <a href="<c:url value='/jahia/page-composer/default/${siteLocale}${node.path}${page}.html'/>" target="_parent">
                                     <i class="material-icons">arrow_forward</i>
                                 </a>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15819

## Description
* Added pageComposerAccess 
* Default redirect url to JContent if user has jContentAccess and/or pageComposerAccess
* Linked to Page Composer if user has pageComposerAccess but not jContentAccess
* Show `blocked` icon if user neither have pageComposerAccess nor jContentAccess 
