### PR TITLE
QA-13494: Add logic to display home URL for preview link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-depends>default,contentRetrieval,jcrestapi</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MC0CFBOUiWJoc8+JdkWi4+SqQFugiLD+AhUAh+/le+4aPIM9zmAqsUGRiGZaShk=</jahia-module-signature>
+        <jahia-module-signature>MCwCFGqGnh5LRFeo5U1yyhitDo/eghWHAhRWJKkSb4qymnk6muC0Ks5H4j34ow==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
     </properties>
 

--- a/src/main/resources/jnt_listSites/html/sitesTableRow.jspf
+++ b/src/main/resources/jnt_listSites/html/sitesTableRow.jspf
@@ -217,8 +217,16 @@
                        value="${jcr:getFirstAllowedNodeForPermission('jContentAccess', node, 'jnt:page')}"/>
                 <c:set var="contributeModeAccessNode"
                        value="${jcr:getFirstAllowedNodeForPermission('contributeModeAccess', node, 'jnt:page')}"/>
-                <c:set var="previewModeAccessNode"
-                       value="${jcr:getFirstAllowedNodeForPermission('jcr:read_default', node, 'jnt:page')}"/>
+
+                <%-- check home page for read permission otherwise, return first allowed node --%>
+                <c:if test="${jcr:hasPermission(node.home, 'jcr:read_default')}">
+                    <c:set var="previewModeAccessNode" value="${node.home}"/>
+                </c:if>
+                <c:if test="${empty previewModeAccessNode}">
+                    <c:set var="previewModeAccessNode"
+                           value="${jcr:getFirstAllowedNodeForPermission('jcr:read_default', node, 'jnt:page')}"/>
+                </c:if>
+
                 <c:choose>
                 <c:when test="${node.home.properties['j:published'].boolean or not empty jContentAccessNode or not empty contributeModeAccessNode or not empty previewModeAccessNode}">
                     <c:set var="baseLive" value="${url.baseLive}"/>

--- a/src/main/resources/jnt_listSites/html/sitesTableRow.settingsBootstrap3GoogleMaterialStyle.jspf
+++ b/src/main/resources/jnt_listSites/html/sitesTableRow.settingsBootstrap3GoogleMaterialStyle.jspf
@@ -184,8 +184,16 @@
                        value="${jcr:getFirstAllowedNodeForPermission('jContentAccess', node, 'jnt:page')}"/>
                 <c:set var="contributeModeAccessNode"
                        value="${jcr:getFirstAllowedNodeForPermission('contributeModeAccess', node, 'jnt:page')}"/>
-                <c:set var="previewModeAccessNode"
-                       value="${jcr:getFirstAllowedNodeForPermission('jcr:read_default', node, 'jnt:page')}"/>
+
+                <%-- check home page for read permission otherwise, return first allowed node --%>
+                <c:if test="${jcr:hasPermission(node.home, 'jcr:read_default')}">
+                    <c:set var="previewModeAccessNode" value="${node.home}"/>
+                </c:if>
+                <c:if test="${empty previewModeAccessNode}">
+                    <c:set var="previewModeAccessNode"
+                           value="${jcr:getFirstAllowedNodeForPermission('jcr:read_default', node, 'jnt:page')}"/>
+                </c:if>
+
                 <c:choose>
                     <c:when test="${node.home.properties['j:published'].boolean or not empty jContentAccessNode or not empty contributeModeAccessNode or not empty previewModeAccessNode}">
                         <c:set var="baseLive" value="${url.baseLive}"/>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13494

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add logic to display home URL for preview link if user has `jcr:read_default` permission for the home page node. 
