### PR TITLE
fix: Unable to edit privacy information

### DIFF
--- a/src/main/resources/javascript/editUserDetailsUtils.js
+++ b/src/main/resources/javascript/editUserDetailsUtils.js
@@ -53,7 +53,7 @@ function formToJahiaCreateUpdateProperties(formId, nodeIdentifier, locale, field
             }
         `;
         const variables = {nodeId: nodeIdentifier};
-        execGraphQL(context,query,variables)
+        execGraphQL(context, query, variables)
             .then(() => reload(fullReload));
 
     } else {
@@ -279,13 +279,13 @@ function verifyAndSubmitAddress(cssClass, phoneErrorId, emailErrorId) {
 /**
  * Update the privacy information for the user with their public/private properties.
  */
-function updatePrivacyInformation() {
+function updatePrivacyInformation(userNodeIdentifier) {
     // get selected public properties
     var publicPropertiesValues = $('input[name="j:publicProperties"]').filter(':checked').map(function () {
         return this.value;
     }).get();
 
-    updateNodePropertyValues(nodeIdentifier, "j:publicProperties", publicPropertiesValues)
+    updateNodePropertyValues(userNodeIdentifier, "j:publicProperties", publicPropertiesValues)
         .then(() => reload());
 
 }

--- a/src/main/resources/jnt_editUserDetails/html/editUserDetailsRows.settingsBootstrap3GoogleMaterialStyle.jspf
+++ b/src/main/resources/jnt_editUserDetails/html/editUserDetailsRows.settingsBootstrap3GoogleMaterialStyle.jspf
@@ -758,7 +758,7 @@
                     </div>
                     <div class="form-actions" style="float:right;">
                         <button type="button" class="btn btn-default" onclick="switchRow('privacy')"><fmt:message key="cancel"/></button>
-                        <button class="btn btn-primary btn-raised" type="button" onclick="updatePrivacyInformation();">
+                        <button class="btn btn-primary btn-raised" type="button" onclick="updatePrivacyInformation('${user.identifier}');">
                             <fmt:message key="save"/>
                         </button>
                         <div class="otherField errorMessage"></div>


### PR DESCRIPTION
### Description
Addresses https://github.com/Jahia/userDashboard/issues/60.
Fix a Javascript issue where it was not possible to edit the privacy information details on the user profile page.

