### PR TITLE
fix: Use textarea when ckeditor module is not available

### DIFF
--- a/.chachalog/AzCO9t3p.md
+++ b/.chachalog/AzCO9t3p.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+userDashboard: minor
+---
+
+Use fallback textarea when ckeditor is not available (#82)

--- a/src/main/resources/javascript/editUserDetailsUtils.js
+++ b/src/main/resources/javascript/editUserDetailsUtils.js
@@ -428,15 +428,18 @@ function deletePhoto(userId) {
         .catch(error => formError(error));
 }
 
-
 function saveCkEditorChanges(nodeIdentifier) {
-
-    var editor = CKEDITOR.instances['about_editor'];
-    var editorValue = editor.getData().trim();
+    let editorValue;
+    if (typeof CKEDITOR !== 'undefined') {
+        const editor = CKEDITOR.instances['about_editor'];
+        editorValue = editor.getData().trim();
+    } else {
+        // Use fallback <textarea id="about_editor"> in editUserDetails jsp if CKEDITOR is undefined
+        editorValue = $('#about_editor').val().trim();
+    }
 
     updateNodePropertyValue(nodeIdentifier, "j:about", editorValue)
         .then(() => reload());
-
 }
 
 

--- a/src/main/resources/jnt_editUserDetails/html/editUserDetails.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_editUserDetails/html/editUserDetails.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -64,7 +64,7 @@
 <template:addResources type="javascript" resources="jquery.min.js,jquery-ui.min.js"/>
 <template:addResources type="javascript" resources="bootstrap-3/bootstrap-switch.js"/>
 <template:addResources type="javascript" resources="jquery.ajaxfileupload.js"/>
-<template:addResources type="inline"  >
+<template:addResources type="inline">
     <%-- ckeditor can't be loaded with a classic <template:addResources> as it is not declared as a dependency of userDashboard --%>
     <%-- And we want to keep it this way to avoid a global refresh of the bundles when ckeditor is updated, see https://jira.jahia.org/browse/QA-9520 for details --%>
     <script src='<c:url value="/modules/ckeditor/javascript/ckeditor.js" />'></script>
@@ -353,7 +353,9 @@
                                                                 value="${user.properties['j:about'].string}"/></textarea>
                                                         <script type="text/javascript">
                                                             $(document).ready(function () {
-                                                                CKEDITOR.replace('about_editor');
+                                                                if (typeof CKEDITOR !== 'undefined') {
+                                                                    CKEDITOR.replace('about_editor');
+                                                                }
                                                             });
                                                         </script>
                                                         <br />


### PR DESCRIPTION
### Description

Use fallback textarea to edit `j:about` user properties if ckeditor module is not available. 